### PR TITLE
Node version 20.0.0 doesn't work even though its the minimum required

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "start": "node --loader ts-node/esm --env-file=.env --no-warnings ./src/run.ts"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.6.0"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
- The built in .env file support [starts](https://nodejs.org/en/blog/release/v20.6.0) from 20.6.0
- Changed minimum version to 20.6.0

![CleanShot 2024-02-08 at 8  37 14](https://github.com/ustas-eth/issue-calculatooor/assets/122114333/50254ea5-71b8-427c-a5f5-da6338a9b6ad)
